### PR TITLE
Implement the getProvider API

### DIFF
--- a/packages/connect-kit-loader/src/index.ts
+++ b/packages/connect-kit-loader/src/index.ts
@@ -1,11 +1,82 @@
-export type LedgerConnectKit = {
-  checkConnectSupport: Function;
-  showModal: Function;
+// support
+
+export type ConnectSupport = {
+  isConnectSupported: boolean;
+  isLedgerConnectExtensionLoaded: boolean;
+  isLedgerLiveMobileInstalled: boolean | undefined;
+  isWebUSBSupported: boolean;
+  isU2FSupported: boolean;
 };
+
+export interface ConnectSupportFunction {
+  (): ConnectSupport;
+}
+
+// ethereum
+
+export interface EthereumProvider {
+  providers?: EthereumProvider[]
+  request(...args: any[]): Promise<any>
+  on(...args: any[]): void
+  removeListener(...args: any[]): void
+}
+
+export interface GetEthereumProviderFunction {
+  (): EthereumProvider | null
+}
+
+// solana
+
+export interface SolanaProvider {
+  signTransaction(...args: any[]): Promise<any>
+  signAllTransactions(...args: any[]): Promise<any>
+  signAndSendTransaction(...args: any[]): Promise<any>
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+}
+
+export interface GetSolanaProviderFunction {
+  (): SolanaProvider | null
+}
+
+// getProvider
+
+export const SupportedProviders = {
+  ethereum: 'ethereum',
+  solana: 'solana'
+} as const;
+export type SupportedProvidersType = typeof SupportedProviders
+export type SupportedProvider =  SupportedProvidersType[keyof SupportedProvidersType]
+
+export interface GetProviderFunction {
+  (provider: SupportedProvider): EthereumProvider | SolanaProvider | null
+}
+
+// modal
+
+export type ShowModalOptions = ConnectSupport & { connectorSupportsUsb: boolean }
+
+export type ShowModalResult = {
+  error?: Error
+}
+
+export interface ShowModalFunction {
+  (params: ShowModalOptions): ShowModalResult
+}
+
+export type LedgerConnectKit = {
+  checkConnectSupport: ConnectSupportFunction;
+  getProvider: GetProviderFunction;
+  getEthereumProvider: GetEthereumProviderFunction;
+  getSolanaProvider: GetSolanaProviderFunction;
+  showModal: ShowModalFunction;
+};
+
+// script loader
 
 function loadScript(src: string, globalName: string): Promise<any> {
   return new Promise((resolve, reject) => {
-    const scriptId = `lckit-script-${globalName}`
+    const scriptId = `ledger-ck-script-${globalName}`
 
     if (document.getElementById(scriptId)) {
       resolve((window as { [key: string]: any })[globalName])

--- a/packages/connect-kit-loader/src/index.ts
+++ b/packages/connect-kit-loader/src/index.ts
@@ -8,69 +8,49 @@ export type ConnectSupport = {
   isU2FSupported: boolean;
 };
 
-export interface ConnectSupportFunction {
-  (): ConnectSupport;
-}
+export type ConnectSupportFunction = () => ConnectSupport;
 
 // ethereum
 
 export interface EthereumProvider {
-  providers?: EthereumProvider[]
-  request(...args: any[]): Promise<any>
-  on(...args: any[]): void
-  removeListener(...args: any[]): void
+  providers?: EthereumProvider[];
+  request(...args: unknown[]): Promise<unknown>;
+  on(...args: unknown[]): void;
+  removeListener(...args: unknown[]): void;
 }
 
-export interface GetEthereumProviderFunction {
-  (): EthereumProvider | null
-}
+export type GetEthereumProviderFunction = () => EthereumProvider | null;
 
 // solana
 
 export interface SolanaProvider {
-  signTransaction(...args: any[]): Promise<any>
-  signAllTransactions(...args: any[]): Promise<any>
-  signAndSendTransaction(...args: any[]): Promise<any>
-  connect(): Promise<void>
-  disconnect(): Promise<void>
+  signTransaction(...args: unknown[]): Promise<unknown>;
+  signAllTransactions(...args: unknown[]): Promise<unknown>;
+  signAndSendTransaction(...args: unknown[]): Promise<unknown>;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
 }
 
-export interface GetSolanaProviderFunction {
-  (): SolanaProvider | null
-}
+export type GetSolanaProviderFunction = () => SolanaProvider | null;
 
 // getProvider
 
-export const SupportedProviders = {
-  ethereum: 'ethereum',
-  solana: 'solana'
-} as const;
-export type SupportedProvidersType = typeof SupportedProviders
-export type SupportedProvider =  SupportedProvidersType[keyof SupportedProvidersType]
-
-export interface GetProviderFunction {
-  (provider: SupportedProvider): EthereumProvider | SolanaProvider | null
+export enum SupportedProviders {
+  ethereum = 'ethereum',
+  solana = 'solana'
 }
+
+export type GetProviderFunction = (provider: SupportedProviders) => EthereumProvider | SolanaProvider | null;
 
 // modal
 
-export type ShowModalOptions = ConnectSupport & { connectorSupportsUsb: boolean }
+export type ShowModalOptions = ConnectSupport & { connectorSupportsUsb?: boolean }
 
 export type ShowModalResult = {
   error?: Error
 }
 
-export interface ShowModalFunction {
-  (params: ShowModalOptions): ShowModalResult
-}
-
-export type LedgerConnectKit = {
-  checkConnectSupport: ConnectSupportFunction;
-  getProvider: GetProviderFunction;
-  getEthereumProvider: GetEthereumProviderFunction;
-  getSolanaProvider: GetSolanaProviderFunction;
-  showModal: ShowModalFunction;
-};
+export type ShowModalFunction = (params: ShowModalOptions) => ShowModalResult;
 
 // script loader
 
@@ -93,6 +73,14 @@ function loadScript(src: string, globalName: string): Promise<any> {
     document.head.appendChild(script)
   })
 }
+
+export interface LedgerConnectKit {
+  checkConnectSupport: ConnectSupportFunction;
+  getProvider: GetProviderFunction;
+  getEthereumProvider: GetEthereumProviderFunction;
+  getSolanaProvider: GetSolanaProviderFunction;
+  showModal: ShowModalFunction;
+};
 
 export async function loadConnectKit(): Promise<LedgerConnectKit> {
   const CONNECT_KIT_CDN_URL = "https://incomparable-duckanoo-b48572.netlify.app/umd/index.js"

--- a/packages/connect-kit/src/index.ts
+++ b/packages/connect-kit/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./lib/checkConnectSupport";
+export * from "./lib/getProvider";
 export * from "./lib/showModal";

--- a/packages/connect-kit/src/lib/checkConnectSupport.ts
+++ b/packages/connect-kit/src/lib/checkConnectSupport.ts
@@ -44,14 +44,9 @@ export type ConnectSupport = {
 export function checkConnectSupport(): ConnectSupport {
   const device = getBrowser();
 
-  const hasConnectEthereumProvider = !!getEthereumProvider();
-
-  // check extension enabled
-  const isLedgerConnectExtensionLoaded = hasConnectEthereumProvider;
-
   return {
     isConnectSupported: isConnectSupported(device),
-    isLedgerConnectExtensionLoaded,
+    isLedgerConnectExtensionLoaded: !!getEthereumProvider(),
     isLedgerLiveMobileInstalled: undefined,
     isWebUSBSupported: isWebUSBSupported(),
     isU2FSupported: isU2FSupported(device)

--- a/packages/connect-kit/src/lib/checkConnectSupport.ts
+++ b/packages/connect-kit/src/lib/checkConnectSupport.ts
@@ -1,4 +1,5 @@
 import { Device, getBrowser } from "./getBrowser";
+import { getEthereumProvider } from "./getProvider";
 
 /* USB support */
 
@@ -27,22 +28,15 @@ const isU2FSupported = (device: Device): boolean => {
 
 /* Ledger Connect extension support */
 
-type InjectedProvider = Record<string, boolean> &
-  Record<string, InjectedProvider[]>;
-
-interface CustomWindow extends Window {
-  ethereum: InjectedProvider;
+// check if Connect supports the user's platform
+function isConnectSupported (device: Device): boolean {
+  return (device.os.name === "iOS" && device.browser.name === "Safari");
 }
-
-declare const window: CustomWindow;
-const LEDGER_CONNECT_NAMESPACE = "ethereum";
-const LEDGER_CONNECT_IDENTIFIER = "isLedgerConnect";
 
 export type ConnectSupport = {
   isConnectSupported: boolean,
-  isProviderDefined: boolean,
   isLedgerConnectExtensionLoaded: boolean,
-  isLedgerLiveMobileInstalled: boolean,
+  isLedgerLiveMobileInstalled: boolean | undefined,   // not used yet
   isWebUSBSupported: boolean,
   isU2FSupported: boolean
 }
@@ -50,26 +44,15 @@ export type ConnectSupport = {
 export function checkConnectSupport(): ConnectSupport {
   const device = getBrowser();
 
-  // check Connect support, currently Safari only on iOS/iPadOS
-  const isConnectSupported =
-    device.os.name === "iOS" && device.browser.name === "Safari";
-
-  // TODO check if LLM is installed, do a deep link request
-  const isLedgerLiveMobileInstalled = false;
-
-  // check provider
-  const provider = window[LEDGER_CONNECT_NAMESPACE];
-  const isProviderDefined = !!provider;
+  const hasConnectEthereumProvider = !!getEthereumProvider();
 
   // check extension enabled
-  const isLedgerConnectExtensionLoaded =
-    !!provider && !!provider[LEDGER_CONNECT_IDENTIFIER];
+  const isLedgerConnectExtensionLoaded = hasConnectEthereumProvider;
 
   return {
-    isConnectSupported,
-    isProviderDefined,
+    isConnectSupported: isConnectSupported(device),
     isLedgerConnectExtensionLoaded,
-    isLedgerLiveMobileInstalled,
+    isLedgerLiveMobileInstalled: undefined,
     isWebUSBSupported: isWebUSBSupported(),
     isU2FSupported: isU2FSupported(device)
   };

--- a/packages/connect-kit/src/lib/getProvider.ts
+++ b/packages/connect-kit/src/lib/getProvider.ts
@@ -1,11 +1,9 @@
-export const SupportedProviders = {
-  ethereum: 'ethereum',
-  solana: 'solana'
-} as const;
-type SupportedProvidersType = typeof SupportedProviders
-export type SupportedProvider = SupportedProvidersType[keyof SupportedProvidersType]
+export enum SupportedProviders {
+  ethereum = 'ethereum',
+  solana = 'solana'
+}
 
-export function getProvider (provider: SupportedProvider) {
+export function getProvider (provider: SupportedProviders) {
   switch (provider) {
     case SupportedProviders.ethereum:
       return getEthereumProvider()
@@ -13,7 +11,7 @@ export function getProvider (provider: SupportedProvider) {
     case SupportedProviders.solana:
       return getSolanaProvider()
       break
-    defualt:
+    default:
       return null
   }
 }
@@ -24,15 +22,15 @@ export const LEDGER_ETHEREUM_PROVIDER = 'ethereum'
 export const LEDGER_CONNECT_ETHEREUM_PROP = 'isLedgerConnect'
 
 export interface EthereumProvider {
-  [LEDGER_CONNECT_ETHEREUM_PROP]: boolean
-  providers?: EthereumProvider[]
-  on(): void
-  request(): Promise<any>
-  removeListener(): void
+  [LEDGER_CONNECT_ETHEREUM_PROP]: boolean;
+  providers?: EthereumProvider[];
+  request(...args: unknown[]): Promise<unknown>;
+  on(...args: unknown[]): void;
+  removeListener(...args: unknown[]): void;
 }
 
-export declare interface WindowWithEthereum {
-  [LEDGER_ETHEREUM_PROVIDER]?: EthereumProvider
+export interface WindowWithEthereum {
+  [LEDGER_ETHEREUM_PROVIDER]?: EthereumProvider;
 }
 
 export function getEthereumProvider () {
@@ -51,15 +49,15 @@ export const LEDGER_SOLANA_PROVIDER = 'solana'
 export const LEDGER_CONNECT_SOLANA_PROP = 'isPhantom'
 
 export interface SolanaProvider {
-  [LEDGER_CONNECT_SOLANA_PROP]: boolean
-  signTransaction(...args: any[]): Promise<any>
-  signAllTransactions(...args: any[]): Promise<any>
-  signAndSendTransaction(...args: any[]): Promise<any>
-  connect(): Promise<void>
-  disconnect(): Promise<void>
+  [LEDGER_CONNECT_SOLANA_PROP]: boolean;
+  signTransaction(...args: unknown[]): Promise<unknown>;
+  signAllTransactions(...args: unknown[]): Promise<unknown>;
+  signAndSendTransaction(...args: unknown[]): Promise<unknown>;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
 }
 
-export declare interface WindowWithSolana {
+export interface WindowWithSolana {
   [LEDGER_SOLANA_PROVIDER]?: SolanaProvider
 }
 

--- a/packages/connect-kit/src/lib/getProvider.ts
+++ b/packages/connect-kit/src/lib/getProvider.ts
@@ -1,0 +1,74 @@
+export const SupportedProviders = {
+  ethereum: 'ethereum',
+  solana: 'solana'
+} as const;
+type SupportedProvidersType = typeof SupportedProviders
+export type SupportedProvider = SupportedProvidersType[keyof SupportedProvidersType]
+
+export function getProvider (provider: SupportedProvider) {
+  switch (provider) {
+    case SupportedProviders.ethereum:
+      return getEthereumProvider()
+      break
+    case SupportedProviders.solana:
+      return getSolanaProvider()
+      break
+    defualt:
+      return null
+  }
+}
+
+// Ethereum provider
+
+export const LEDGER_ETHEREUM_PROVIDER = 'ethereum'
+export const LEDGER_CONNECT_ETHEREUM_PROP = 'isLedgerConnect'
+
+export interface EthereumProvider {
+  [LEDGER_CONNECT_ETHEREUM_PROP]: boolean
+  providers?: EthereumProvider[]
+  on(): void
+  request(): Promise<any>
+  removeListener(): void
+}
+
+export declare interface WindowWithEthereum {
+  [LEDGER_ETHEREUM_PROVIDER]?: EthereumProvider
+}
+
+export function getEthereumProvider () {
+  const provider = (window as WindowWithEthereum)[LEDGER_ETHEREUM_PROVIDER]
+
+  if (typeof provider !== "undefined" && provider[LEDGER_CONNECT_ETHEREUM_PROP]) {
+    return provider
+  }
+
+  return null
+};
+
+// Solana provider
+
+export const LEDGER_SOLANA_PROVIDER = 'solana'
+export const LEDGER_CONNECT_SOLANA_PROP = 'isPhantom'
+
+export interface SolanaProvider {
+  [LEDGER_CONNECT_SOLANA_PROP]: boolean
+  signTransaction(...args: any[]): Promise<any>
+  signAllTransactions(...args: any[]): Promise<any>
+  signAndSendTransaction(...args: any[]): Promise<any>
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+}
+
+export declare interface WindowWithSolana {
+  [LEDGER_SOLANA_PROVIDER]?: SolanaProvider
+}
+
+export function getSolanaProvider () {
+  const provider = (window as WindowWithSolana)[LEDGER_SOLANA_PROVIDER]
+
+  if (typeof provider !== "undefined" && provider[LEDGER_CONNECT_SOLANA_PROP]) {
+    return provider
+  }
+
+  return null
+}

--- a/packages/connect-kit/src/lib/showModal.tsx
+++ b/packages/connect-kit/src/lib/showModal.tsx
@@ -40,34 +40,29 @@ const rendererModal = (modalType: ModalType): void => {
 
 type showModalOptions = ConnectSupport & { connectorSupportsUsb: boolean }
 
+type ShowModalResult = {
+  error?: Error
+}
+
 export const showModal = ({
   isConnectSupported,
   isLedgerConnectExtensionLoaded,
   isWebUSBSupported,
   isU2FSupported,
   connectorSupportsUsb = false,
-}: showModalOptions) => {
+}: showModalOptions): ShowModalResult => {
   let error;
 
   if (!root) {
     const el = document.body;
     const container = document.createElement("div");
-    container.className = "-lcuikit-modal";
+    container.className = "ledger-ck-modal";
     el.appendChild(container);
     root = createRoot(container)
   }
 
-  console.log('support props are ', {
-    isConnectSupported,
-    isLedgerConnectExtensionLoaded,
-    isWebUSBSupported,
-    isU2FSupported,
-    connectorSupportsUsb})
-
   const isUSBSupported = connectorSupportsUsb && (isWebUSBSupported || isU2FSupported)
   const noSupportedTransports = !isConnectSupported && !isUSBSupported
-
-  console.log('no supported transports is ', noSupportedTransports)
 
   if (noSupportedTransports) {
     // if none of the connection methods is supported, show the Platform Not

--- a/packages/connect-kit/src/lib/showModal.tsx
+++ b/packages/connect-kit/src/lib/showModal.tsx
@@ -38,7 +38,7 @@ const rendererModal = (modalType: ModalType): void => {
   }
 }
 
-type showModalOptions = ConnectSupport & { connectorSupportsUsb: boolean }
+type showModalOptions = ConnectSupport & { connectorSupportsUsb?: boolean }
 
 type ShowModalResult = {
   error?: Error


### PR DESCRIPTION
- export types on connect-kit-loader package (currently duplicated on both packages, will look more into bundler config later)
- rename ids used on the script and modal div HTML tags
- export a getProvider function that accepts "ethereum" or "solana" as a parameter
- export getEthereumProvider and getSolanaProvider functions