### PR TITLE
Feat/lc 304 setup release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository is used to build two packages, `@ledgerhq/connect-kit-loader` and `@ledgerhq/connect-kit`.
 
-More information is available on the [connect-kit-loader README.md](packages/connect-kit-loader/README.md) file.
+More information is available on the [connect-kit-loader](packages/connect-kit-loader) package.

--- a/packages/connect-kit-loader/.github/workflows/release_package.yml
+++ b/packages/connect-kit-loader/.github/workflows/release_package.yml
@@ -1,0 +1,93 @@
+name: Release Connect Kit Loader
+concurrency: release-ckl-${{ github.repository }}
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type (one of): patch, minor, major, prepatch, preminor, premajor, prerelease'
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout project repository
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup Node.js environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: '16'
+
+      # Bump package version
+      # Use tag latest
+      - name: Bump release version
+        if: startsWith(github.event.inputs.release-type, 'pre') != true
+        run: |
+          cd packages/connect-kit-loader
+          echo "NEW_VERSION=$(yarn --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      # Bump package pre-release version
+      # Use tag beta for pre-release versions
+      - name: Bump pre-release version
+        if: startsWith(github.event.inputs.release-type, 'pre')
+        run: |
+          cd packages/connect-kit-loader
+          echo "NEW_VERSION=$(yarn --no-git-tag-version --preid=beta version --$RELEASE_TYPE
+          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      # Update changelog unreleased section with new version
+      - name: Update changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: packages/connect-kit-loader/CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: release
+
+      # Commit changes
+      - name: Commit CHANGELOG.md and package.json changes and create tag
+        run: |
+          cd packages/connect-kit-loader
+          git add "package.json"
+          git add "CHANGELOG.md"
+          git commit -m "chore: release Connect Kit ${{ env.NEW_VERSION }}"
+          git tag ckl-${{ env.NEW_VERSION }}
+
+      # Publish version to public repository
+      - name: Publish
+        run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
+      # Push repository changes
+      - name: Push changes to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin && git push --tags
+
+      # Read version changelog
+      - id: get-changelog
+        name: Get version changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: read
+
+      # Update GitHub release with changelog
+      - name: Update GitHub release documentation
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.NEW_VERSION }}
+          body: ${{ steps.get-changelog.outputs.changelog }}
+          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/connect-kit-loader/CHANGELOG.md
+++ b/packages/connect-kit-loader/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This is the first public version of the package.
+
+### Added
+
+- Load the Connect Kit script from a CDN.

--- a/packages/connect-kit-loader/package.json
+++ b/packages/connect-kit-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/connect-kit-loader",
-  "version": "0.9.0-beta1",
+  "version": "1.0.0-beta.0",
   "description": "Loads Ledger Connect Kit at runtime",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
@@ -9,6 +9,11 @@
     "dist"
   ],
   "types": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/connect-kit",
+    "directory": "packages/connect-kit-loader"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c --compact"

--- a/packages/connect-kit/.github/workflows/release_package.yml
+++ b/packages/connect-kit/.github/workflows/release_package.yml
@@ -1,0 +1,93 @@
+name: Release Connect Kit
+concurrency: release-ck-${{ github.repository }}
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type (one of): patch, minor, major, prepatch, preminor, premajor, prerelease'
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout project repository
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup Node.js environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          registry-url: https://registry.npmjs.org/
+          node-version: '16'
+
+      # Bump package version
+      # Use tag latest
+      - name: Bump release version
+        if: startsWith(github.event.inputs.release-type, 'pre') != true
+        run: |
+          cd packages/connect-kit
+          echo "NEW_VERSION=$(yarn --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=latest" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      # Bump package pre-release version
+      # Use tag beta for pre-release versions
+      - name: Bump pre-release version
+        if: startsWith(github.event.inputs.release-type, 'pre')
+        run: |
+          cd packages/connect-kit
+          echo "NEW_VERSION=$(yarn --no-git-tag-version --preid=beta version --$RELEASE_TYPE
+          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release-type }}
+
+      # Update changelog unreleased section with new version
+      - name: Update changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: packages/connect-kit/CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: release
+
+      # Commit changes
+      - name: Commit CHANGELOG.md and package.json changes and create tag
+        run: |
+          cd packages/connect-kit
+          git add "package.json"
+          git add "CHANGELOG.md"
+          git commit -m "chore: release Connect Kit ${{ env.NEW_VERSION }}"
+          git tag ck-${{ env.NEW_VERSION }}
+
+      # Publish version to public repository
+      - name: Publish
+        run: yarn publish --verbose --access public --tag ${{ env.RELEASE_TAG }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
+      # Push repository changes
+      - name: Push changes to repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin && git push --tags
+
+      # Read version changelog
+      - id: get-changelog
+        name: Get version changelog
+        uses: superfaceai/release-changelog-action@v1
+        with:
+          path-to-changelog: CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: read
+
+      # Update GitHub release with changelog
+      - name: Update GitHub release documentation
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.NEW_VERSION }}
+          body: ${{ steps.get-changelog.outputs.changelog }}
+          prerelease: ${{ startsWith(github.event.inputs.release-type, 'pre') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This is the first public version of the package.
+
+### Added
+
+- Show a modal to guide the user.
+- Get a Ledger Connect provider on Safari on iOS when connecting to chainId 1.
+- Get a WalletConnect provider when on other platforms and chainIds.

--- a/packages/connect-kit/README.md
+++ b/packages/connect-kit/README.md
@@ -1,3 +1,3 @@
 # Ledger Connect Kit
 
-Please read the [connect-kit-loader README.md](../connect-kit-loader/README.md) file.
+Please read the information available on the [connect-kit-loader](/packages/connect-kit-loader) package.

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/connect-kit",
-  "version": "0.9.0-beta1",
+  "version": "1.0.0-beta.0",
   "description": "",
   "main": "dist/umd/index.js",
   "module": "dist/umd/index.js",
@@ -8,6 +8,11 @@
     "dist"
   ],
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/connect-kit",
+    "directory": "packages/connect-kit"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "rollup": "rollup -c",


### PR DESCRIPTION
NOTE: depends on the previous PR

Implements semi-automated release publishing

- update version and repository information for both packages
- add GitHub workflow to automate versioning and publishing of the
  packages, each package currently has an identical workflow file,
  only the paths and git tags change
- add CHANGELOG.md for both packages

Process is:

- add entries to the Unreleased section of the CHANGELOG.md file on each
  package while working on the code
- merge PR into main branch when done
- on the GitHub project's *Actions* tab select the *Release package*
  action
    - specify the release type: patch, minor, major, prepatch, preminor,
      premajor, or prerelease
    - press *Run workflow*
    - the action will
        - bump the package release version (latest)
          or pre-release version (beta)
        - update CHANGELOG.md by moving the entries under Unreleased to the
          new version number
        - commit `CHANGELOG.md` and `package.json`
        - publish the package to NPM using yarn publish, using the
          *latest* tag for release versions and *beta* for prerelease
          ones
        - push the changes to the repo
        - update GitHub release