### PR TITLE
Reject when user closes modal, other fixes

### DIFF
--- a/packages/connect-kit-loader/package.json
+++ b/packages/connect-kit-loader/package.json
@@ -19,6 +19,7 @@
   "files": [
     "dist"
   ],
+  "type":"module",
   "types": "index",
   "homepage": "https://get-connect.ledger.com",
   "repository": {

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Don't open a blank tab when pressing the User Ledger Live deeplink.
+- Patch the provider's request method to handle the Connect With Ledger Live
+  modal in the `eth_requestAccounts` method, allowing us to reject with the
+  "user rejected connection" error when the modal is closed.
+
 ## 1.0.0 - 2022-11-17
 ### Changed
 - Promoted to 1.0.

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Don't open a blank tab when pressing the User Ledger Live deeplink.
+- Correctly detect the Brave browser on iOS.
 - Patch the provider's request method to handle the Connect With Ledger Live
   modal in the `eth_requestAccounts` method, allowing us to reject with the
   "user rejected connection" error when the modal is closed.

--- a/packages/connect-kit/src/components/ConnectWithLedgerLiveModal/ConnectWithLedgerLiveModal.tsx
+++ b/packages/connect-kit/src/components/ConnectWithLedgerLiveModal/ConnectWithLedgerLiveModal.tsx
@@ -33,10 +33,12 @@ export let setWalletConnectUri = (uri: string): void => {
 
 export type ConnectWithLedgerLiveModalProps = {
   withQrCode?: boolean;
+  onClose?: () => void;
 }
 
 const ConnectWithLedgerLiveModal = ({
-  withQrCode = false
+  withQrCode = false,
+  onClose = () => void 0,
 }: ConnectWithLedgerLiveModalProps) => {
   log('initializing', { withQrCode });
   log('walletConnectUri', walletConnectUri);
@@ -49,7 +51,7 @@ const ConnectWithLedgerLiveModal = ({
   setModalDeeplink = setDeeplink;
 
   const onUseLedgerLiveClick = () => {
-    window.open(deeplink);
+    window.location.href = deeplink;
     return false;
   };
 
@@ -59,7 +61,7 @@ const ConnectWithLedgerLiveModal = ({
   };
 
   return (
-    <Modal>
+    <Modal onClose={() => onClose()}>
       <>
         <ModalSection>
           <ModalTitle>Use Ledger Live</ModalTitle>

--- a/packages/connect-kit/src/components/Modal/Modal.tsx
+++ b/packages/connect-kit/src/components/Modal/Modal.tsx
@@ -8,16 +8,18 @@ export let setIsModalOpen = (isModalOpen: boolean) => {};
 
 interface ModalProps {
   isOpen?: boolean;
+  onClose?: () => void;
   children: ReactElement | null;
 }
 
-export const Modal = ({ children }: ModalProps) => {
+export const Modal = ({ onClose, children }: ModalProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   // assign the set state function to the exported one
   setIsModalOpen = setIsOpen;
 
   const handleClose = () => {
     setIsModalOpen(false);
+    onClose && onClose();
   };
 
   if (isOpen) {

--- a/packages/connect-kit/src/lib/browser.ts
+++ b/packages/connect-kit/src/lib/browser.ts
@@ -23,6 +23,7 @@ declare type DeviceBrowserName =
   | "Firefox"
   | "Microsoft Edge"
   | "Opera"
+  | "Brave"
   | "Safari";
 
 declare type DeviceType = "desktop" | "mobile" | "tablet";
@@ -33,11 +34,25 @@ export declare type Device = {
   browser: DeviceBrowser;
 };
 
+interface BraveNavigator extends Navigator {
+  brave: { isBrave: Function };
+}
+
+function isBrave() {
+  return (
+    (window.navigator as BraveNavigator).brave?.isBrave?.name === "isBrave"
+  )
+}
+
 export function getBrowser(): Device {
   const parsed = bowser.getParser(window.navigator.userAgent);
   const os = parsed.getOS();
   const browser = parsed.getBrowser();
   const { type } = parsed.getPlatform();
+
+  if (isBrave()) {
+    browser.name = "Brave";
+  }
 
   return {
     type: type as DeviceType,

--- a/packages/connect-kit/src/lib/errors.ts
+++ b/packages/connect-kit/src/lib/errors.ts
@@ -13,3 +13,13 @@ export class ProviderTypeIsNotSupportedError extends Error {
     this.message = "The specified provider is not supported.";
   }
 }
+
+export class UserRejectedRequestError extends Error {
+  name = 'UserRejectedRequestError';
+  readonly code: number;
+
+  constructor() {
+    super('User rejected request');
+    this.code = 4001;
+  }
+}

--- a/packages/connect-kit/src/lib/provider.ts
+++ b/packages/connect-kit/src/lib/provider.ts
@@ -1,24 +1,19 @@
 import WalletConnectProvider from "@walletconnect/ethereum-provider/dist/esm";
-import { ProviderTypeIsNotSupportedError } from "./errors";
-import { EthereumProvider, getEthereumProvider } from "../providers/Ethereum";
+import { ProviderTypeIsNotSupportedError, UserRejectedRequestError } from "./errors";
+import { EthereumProvider, EthereumRequestPayload, getEthereumProvider } from "../providers/Ethereum";
 import { getSolanaProvider, SolanaProvider } from "../providers/Solana";
-import { getWalletConnectProvider } from "../providers/WalletConnect";
-import { getDebugLogger } from "./logger";
+import { getWalletConnectProvider, isWalletConnectProviderConnected } from "../providers/WalletConnect";
+import { getDebugLogger, getErrorLogger } from "./logger";
+import { showModal } from "./modal";
+import { getBrowser } from "./browser";
 
 const log = getDebugLogger('getProvider');
+const logError = getErrorLogger('getProvider');
 
 // chains
 
 export enum ConnectSupportedChains {
   EthereumMainnet = 1,
-}
-
-let moduleChainId: ConnectSupportedChains;
-
-export function setChainId(chainId: ConnectSupportedChains): void {
-  log('setChainId', chainId);
-
-  moduleChainId = chainId;
 }
 
 export function isChainIdSupported(chainId: ConnectSupportedChains): boolean {
@@ -41,6 +36,7 @@ export type ProviderResult = EthereumProvider | SolanaProvider | WalletConnectPr
 
 let moduleProviderType: SupportedProviders;
 let moduleProviderImplementation: SupportedProviderImplementations;
+let moduleProviderInstance: EthereumProvider;
 
 export function setProviderType(providerType: SupportedProviders): void {
   log('setProviderType', providerType);
@@ -59,18 +55,74 @@ export function setProviderImplementation(
 export async function getProvider (): Promise<ProviderResult> {
   log('getProvider', moduleProviderType, moduleProviderImplementation);
 
+  if (!!moduleProviderInstance) {
+    log('returning existing provider instance')
+    return moduleProviderInstance;
+  }
+
   switch (moduleProviderType) {
     case SupportedProviders.Ethereum:
+      let provider: EthereumProvider;
+
       if (moduleProviderImplementation === SupportedProviderImplementations.LedgerConnect) {
-        return getEthereumProvider();
+        provider = getEthereumProvider() as EthereumProvider;
+      } else {
+        provider = await getWalletConnectProvider();
       }
 
-      return getWalletConnectProvider();
+      // replace the provider's request function with the patched one
+      provider.request = patchProviderRequest(provider);
+      moduleProviderInstance = provider;
+
+      return provider;
       break;
     case SupportedProviders.Solana:
       return getSolanaProvider();
       break;
     default:
       throw new ProviderTypeIsNotSupportedError();
+  }
+}
+
+function patchProviderRequest (provider: EthereumProvider) {
+  // get the provider's request function so we can call it later
+  const baseRequest = provider.request.bind(provider);
+  const device = getBrowser();
+
+  return async ({ method, params }: EthereumRequestPayload) => {
+    // patch eth_requestAccounts to handle the modal
+    if (method === 'eth_requestAccounts') {
+      log('calling patched', method, params);
+
+      return new Promise<string[]>(async (resolve, reject) => {
+        try {
+          // only show the modal if provider is WalletConnect and there is no
+          // active connection
+          if (
+            moduleProviderImplementation === SupportedProviderImplementations.WalletConnect &&
+            !isWalletConnectProviderConnected()
+          ) {
+            showModal('ConnectWithLedgerLiveModal', {
+              // show the QR code if we are on a desktop browser
+              withQrCode: device.type === 'desktop',
+              // pass an onClose callback that throws when the modal is closed
+              onClose: () => {
+                reject(new UserRejectedRequestError());
+              }
+            });
+          }
+
+          // call the original provider request
+          return resolve(await baseRequest({ method, params }) as string[]);
+        } catch(err) {
+          logError('error', err);
+          return reject(err);
+        }
+      });
+    } else {
+      log('calling provider', method, params);
+      // call the original provider request
+      return await baseRequest({ method, params });
+    }
   }
 }

--- a/packages/connect-kit/src/lib/support.ts
+++ b/packages/connect-kit/src/lib/support.ts
@@ -1,19 +1,15 @@
 import { getEthereumProvider } from "../providers/Ethereum";
 import { getSolanaProvider } from "../providers/Solana";
-import {
-  initWalletConnectProvider,
-  isWalletConnectProviderConnected
-} from "../providers/WalletConnect";
+import { initWalletConnectProvider } from "../providers/WalletConnect";
 import { isLedgerConnectSupported } from "./connectSupport";
 import { getBrowser } from "./browser";
 import {
   ConnectSupportedChains,
   SupportedProviders,
-  setChainId,
   isChainIdSupported,
   setProviderImplementation,
   SupportedProviderImplementations,
-  setProviderType
+  setProviderType,
 } from "./provider";
 import { getDebugLogger } from "./logger";
 import { showModal } from "./modal";
@@ -42,7 +38,6 @@ export function checkSupport(options: CheckSupportOptions): CheckSupportResult {
 
   // default to Ethereum Mainnet if not specified
   const chainId = options.chainId || 1;
-  setChainId(chainId);
 
   switch (options.providerType) {
     case SupportedProviders.Ethereum:
@@ -90,21 +85,12 @@ function checkEthereumSupport(options: CheckEthereumSupportOptions) {
       infuraId: options.infuraId,
       rpc: options.rpc,
     });
-
-    // don't show the modal if the WalletConnect provider is connected
-    if (isWalletConnectProviderConnected()) {
-      return checkSupportResult;
-    }
-
-    // show the QR code if we are on a desktop browser
-    const withQrCode = (device.type === 'desktop');
-    showModal('ConnectWithLedgerLiveModal', { withQrCode });
   } else if (
     checkSupportResult.isLedgerConnectSupported &&
     !checkSupportResult.isLedgerConnectEnabled
   ) {
     // supported platform but Connect is not enabled
-    showModal("ExtensionUnavailableModal");
+    showModal('ExtensionUnavailableModal');
   }
 
   setProviderImplementation(checkSupportResult.providerImplementation);

--- a/packages/connect-kit/src/providers/Ethereum.ts
+++ b/packages/connect-kit/src/providers/Ethereum.ts
@@ -7,13 +7,18 @@ const log = getDebugLogger('LedgerConnectEthereum');
 export const LEDGER_ETHEREUM_PROVIDER = 'ethereum'
 export const LEDGER_CONNECT_ETHEREUM_PROP = 'isLedgerConnect'
 
+export type EthereumRequestPayload = {
+  method: string;
+  params?: unknown[] | object;
+}
+
 export interface EthereumProvider {
   providers?: EthereumProvider[];
-  request(...args: unknown[]): Promise<unknown>;
+  request(payload: EthereumRequestPayload): Promise<unknown>;
   disconnect?: {(): Promise<void>};
   emit(eventName: string | symbol, ...args: any[]): boolean;
-  on(...args: unknown[]): void;
-  removeListener(...args: unknown[]): void;
+  on(event: any, listener: any): void;
+  removeListener(event: string, listener: any): void;
 }
 
 export interface LedgerConnectProvider extends EthereumProvider {

--- a/packages/connect-kit/src/providers/WalletConnect.ts
+++ b/packages/connect-kit/src/providers/WalletConnect.ts
@@ -94,7 +94,6 @@ export async function getWalletConnectProvider(): Promise<EthereumProvider> {
   log('getWalletConnectProvider');
 
   try {
-    await walletConnectProvider.enable();
     return walletConnectProvider as unknown as EthereumProvider;
   } catch (err) {
     const error = (err instanceof Error) ? err : new Error(String(err));


### PR DESCRIPTION
- update Ledger Live deeplink to not open a new tab
- add an onClose prop to ConnectWithLedgerLiveModal and the Modal components so that we can reject a promise when the modal is closed
- add a provider instance variable to the provider module, we now get a Ledger Connect or WalletConnect provider and reuse it
- patch the provider's request method to handle the Connect With Ledger Live modal in the `eth_requestAccounts` method, allowing us to reject with the "user rejected connection" error when the modal is closed
- add an EthereumRequestPayload type and update some EthereumProvider function signatures
- add "type":"module" to package.json to fix import issue in some cases
- update changelog