### PR TITLE
Make sure we always get a new WalletConnect URI

### DIFF
--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -6,10 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+
+- Create a new WalletConnect session each time `eth_requestAccounts` is called
+  (and hence each time the "Use Ledger Live" modal is shown) to avoid reusing
+  the same WalletConnect URI.
+- The "Use Ledger Live" modal is now closed when pressing the "Use Ledger
+  Live" button to avoid the same WalletConnect URI being reused (e.g. if the
+  user clicks "Decline" in Ledger Live and clicks "Use Ledger Live" again.
+- No longer reuse the provider instance in the Provider module as it
+  interferes with refreshing the WalletConnect URI.
+- No longer reuse the provider instance in the WalletConnect module.
 
 ## 1.0.2 - 2022-12-02
 ### Changed
-- Use the ledgerlive: deeplink for que QR code instead of the WalletConnect
+- Use the ledgerlive: deeplink for the QR code instead of the WalletConnect
   URI; this allows scanning the QR code with the native camera app.
 
 ## 1.0.1 - 2022-12-02

--- a/packages/connect-kit/src/components/ConnectWithLedgerLiveModal/ConnectWithLedgerLiveModal.tsx
+++ b/packages/connect-kit/src/components/ConnectWithLedgerLiveModal/ConnectWithLedgerLiveModal.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
 import { getDebugLogger } from "../../lib/logger";
-import Modal from "../Modal/Modal";
+import Modal, { setIsModalOpen } from "../Modal/Modal";
 import {
   ModalButton,
   ModalSection,
@@ -13,39 +12,28 @@ import NeedALedgerSection from "../NeedALedgerSection";
 import { QrCode, QrCodeSection } from "./ConnectWithLedgerLiveModal.styles";
 
 const log = getDebugLogger('ConnectWithLedgerLiveModal');
-let ledgerLiveDeepLink: string;
-
-// placeholder functions until the component is initialized
-let setModalDeeplink = (uri: string) => {};
-
-// called by the WalletConnect display_uri event handler
-export let setWalletConnectUri = (uri: string): void => {
-  log('setModalUri', uri);
-  ledgerLiveDeepLink = `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
-
-  // update internal component state
-  setModalDeeplink(ledgerLiveDeepLink);
-}
 
 export type ConnectWithLedgerLiveModalProps = {
   withQrCode?: boolean;
+  uri?: string;
   onClose?: () => void;
 }
 
 const ConnectWithLedgerLiveModal = ({
   withQrCode = false,
+  uri = '',
   onClose = () => void 0,
 }: ConnectWithLedgerLiveModalProps) => {
-  log('initializing', { withQrCode });
-  log('ledgerLiveDeepLink', ledgerLiveDeepLink);
+  log('initializing', { withQrCode, uri });
 
-  // use the module variables as the initial start values
-  const [deeplink, setDeeplink] = useState<string>(ledgerLiveDeepLink);
-  // replace the placeholder functions by the setState ones
-  setModalDeeplink = setDeeplink;
+  const ledgerLiveDeepLink = `ledgerlive://wc?uri=${encodeURIComponent(uri)}`;
 
   const onUseLedgerLiveClick = () => {
-    window.location.href = deeplink;
+    window.location.href = ledgerLiveDeepLink;
+
+    // close the modal so that the current WalletConnect URI cannot be reused
+    setIsModalOpen(false);
+
     return false;
   };
 

--- a/packages/connect-kit/src/lib/provider.ts
+++ b/packages/connect-kit/src/lib/provider.ts
@@ -1,14 +1,10 @@
-import WalletConnectProvider from "@walletconnect/ethereum-provider/dist/esm";
-import { ProviderTypeIsNotSupportedError, UserRejectedRequestError } from "./errors";
-import { EthereumProvider, EthereumRequestPayload, getEthereumProvider } from "../providers/Ethereum";
+import { ProviderTypeIsNotSupportedError } from "./errors";
+import { EthereumProvider, getEthereumProvider } from "../providers/Ethereum";
 import { getSolanaProvider, SolanaProvider } from "../providers/Solana";
-import { getWalletConnectProvider, isWalletConnectProviderConnected } from "../providers/WalletConnect";
-import { getDebugLogger, getErrorLogger } from "./logger";
-import { showModal } from "./modal";
-import { getBrowser } from "./browser";
+import { getWalletConnectProvider } from "../providers/WalletConnect";
+import { getDebugLogger } from "./logger";
 
 const log = getDebugLogger('getProvider');
-const logError = getErrorLogger('getProvider');
 
 // chains
 
@@ -32,11 +28,10 @@ export enum SupportedProviderImplementations {
   WalletConnect = 'WalletConnect',
 }
 
-export type ProviderResult = EthereumProvider | SolanaProvider | WalletConnectProvider
+export type ProviderResult = EthereumProvider | SolanaProvider
 
 let moduleProviderType: SupportedProviders;
 let moduleProviderImplementation: SupportedProviderImplementations;
-let moduleProviderInstance: EthereumProvider;
 
 export function setProviderType(providerType: SupportedProviders): void {
   log('setProviderType', providerType);
@@ -55,24 +50,15 @@ export function setProviderImplementation(
 export async function getProvider (): Promise<ProviderResult> {
   log('getProvider', moduleProviderType, moduleProviderImplementation);
 
-  if (!!moduleProviderInstance) {
-    log('returning existing provider instance')
-    return moduleProviderInstance;
-  }
-
   switch (moduleProviderType) {
     case SupportedProviders.Ethereum:
       let provider: EthereumProvider;
 
       if (moduleProviderImplementation === SupportedProviderImplementations.LedgerConnect) {
-        provider = getEthereumProvider() as EthereumProvider;
+        provider = getEthereumProvider();
       } else {
         provider = await getWalletConnectProvider();
       }
-
-      // replace the provider's request function with the patched one
-      provider.request = patchProviderRequest(provider);
-      moduleProviderInstance = provider;
 
       return provider;
       break;
@@ -81,48 +67,5 @@ export async function getProvider (): Promise<ProviderResult> {
       break;
     default:
       throw new ProviderTypeIsNotSupportedError();
-  }
-}
-
-function patchProviderRequest (provider: EthereumProvider) {
-  // get the provider's request function so we can call it later
-  const baseRequest = provider.request.bind(provider);
-  const device = getBrowser();
-
-  return async ({ method, params }: EthereumRequestPayload) => {
-    // patch eth_requestAccounts to handle the modal
-    if (method === 'eth_requestAccounts') {
-      log('calling patched', method, params);
-
-      return new Promise<string[]>(async (resolve, reject) => {
-        try {
-          // only show the modal if provider is WalletConnect and there is no
-          // active connection
-          if (
-            moduleProviderImplementation === SupportedProviderImplementations.WalletConnect &&
-            !isWalletConnectProviderConnected()
-          ) {
-            showModal('ConnectWithLedgerLiveModal', {
-              // show the QR code if we are on a desktop browser
-              withQrCode: device.type === 'desktop',
-              // pass an onClose callback that throws when the modal is closed
-              onClose: () => {
-                reject(new UserRejectedRequestError());
-              }
-            });
-          }
-
-          // call the original provider request
-          return resolve(await baseRequest({ method, params }) as string[]);
-        } catch(err) {
-          logError('error', err);
-          return reject(err);
-        }
-      });
-    } else {
-      log('calling provider', method, params);
-      // call the original provider request
-      return await baseRequest({ method, params });
-    }
   }
 }

--- a/packages/connect-kit/src/lib/support.ts
+++ b/packages/connect-kit/src/lib/support.ts
@@ -1,6 +1,6 @@
 import { getEthereumProvider } from "../providers/Ethereum";
 import { getSolanaProvider } from "../providers/Solana";
-import { initWalletConnectProvider } from "../providers/WalletConnect";
+import { setWalletConnectOptions } from "../providers/WalletConnect";
 import { isLedgerConnectSupported } from "./connectSupport";
 import { getBrowser } from "./browser";
 import {
@@ -79,12 +79,12 @@ function checkEthereumSupport(options: CheckEthereumSupportOptions) {
   ) {
     // unsupported platform or chainId, use WalletConnect
     checkSupportResult.providerImplementation = SupportedProviderImplementations.WalletConnect;
-    initWalletConnectProvider({
+    setWalletConnectOptions({
       chainId: options.chainId,
       bridge: options.bridge,
       infuraId: options.infuraId,
       rpc: options.rpc,
-    });
+    })
   } else if (
     checkSupportResult.isLedgerConnectSupported &&
     !checkSupportResult.isLedgerConnectEnabled

--- a/packages/connect-kit/src/providers/Ethereum.ts
+++ b/packages/connect-kit/src/providers/Ethereum.ts
@@ -1,5 +1,4 @@
 import { ProviderNotFoundError } from "../lib/errors";
-import { ProviderResult } from "../lib/provider";
 import { getDebugLogger } from "../lib/logger";
 
 const log = getDebugLogger('LedgerConnectEthereum');
@@ -14,7 +13,7 @@ export type EthereumRequestPayload = {
 
 export interface EthereumProvider {
   providers?: EthereumProvider[];
-  request(payload: EthereumRequestPayload): Promise<unknown>;
+  request<T = unknown>(args: EthereumRequestPayload): Promise<T>;
   disconnect?: {(): Promise<void>};
   emit(eventName: string | symbol, ...args: any[]): boolean;
   on(event: any, listener: any): void;
@@ -29,7 +28,7 @@ interface WindowWithEthereum {
   [LEDGER_ETHEREUM_PROVIDER]?: LedgerConnectProvider;
 }
 
-export function getEthereumProvider (): ProviderResult {
+export function getEthereumProvider (): EthereumProvider {
   log('getEthereumProvider');
 
   const provider = (window as WindowWithEthereum)[LEDGER_ETHEREUM_PROVIDER];


### PR DESCRIPTION
See changelog.

- patching the provider's request method is now done inside the WalletConnect module since it does not affect Ledger Connect
- `ConnectWithLedgerLiveModal` now takes the WalletConnect URI directly as a prop and we don't need to set it externally
- `initWalletConnectProvider` is now called when calling `getProvider` instead of when calling `checkSupport`
- no need to hide the LL modal on the connect or disconnect hadlers since now we close it when clicking the "Use Ledger Live" button