### PR TITLE
Show Ledger Live modal on Safari

### DIFF
--- a/packages/connect-kit/src/lib/modal.tsx
+++ b/packages/connect-kit/src/lib/modal.tsx
@@ -83,3 +83,18 @@ export function showExtensionOrLLModal(props: { uri: string, onClose: Function }
     });
   }
 }
+
+/**
+ * Shows one of two modals depending on if the extension is supported or not.
+ */
+export function showLLModal(props: { uri: string, onClose: Function }) {
+  const device = getBrowser();
+
+  showModal('UseLedgerLiveModal', {
+    // show the QR code if we are on a desktop browser
+    isDesktop: device.type === 'desktop',
+    uri: props.uri,
+    // pass an onClose callback that throws when the modal is closed
+    onClose: props.onClose,
+  });
+}

--- a/packages/connect-kit/src/providers/WalletConnectEvm.ts
+++ b/packages/connect-kit/src/providers/WalletConnectEvm.ts
@@ -3,7 +3,7 @@ import { setIsModalOpen } from '../components/Modal/Modal';
 import { setWalletConnectUri } from '../components/UseLedgerLiveModal/UseLedgerLiveModal';
 import { UserRejectedRequestError } from '../lib/errors';
 import { getDebugLogger, getErrorLogger } from "../lib/logger";
-import { showExtensionOrLLModal } from '../lib/modal';
+import { showLLModal } from '../lib/modal';
 import {
   CheckSupportWalletConnectProviderOptions,
   getSupportOptions
@@ -110,7 +110,7 @@ function patchWalletConnectProviderRequest (provider: WalletConnectProvider) {
       return new Promise(async (resolve, reject) => {
         try {
           if (!provider?.session?.connected) {
-            showExtensionOrLLModal({
+            showLLModal({
               uri: '',
               onClose: () => {
                 logError('user rejected');


### PR DESCRIPTION
Since the development of the extension is paused we don't want to promote it for the time being, and it will be taken of the App Store, so we now show the WalletConnect modal on Safari as well.

- adds a new `showLLModal` function
- `eth_requestAccounts` calls the new function instead of `showExtensionOrLLModal`

Closes #LIVE-7780