### PR TITLE
Test eth_getBalance scenarios

### DIFF
--- a/packages/connect-kit/src/providers/WalletConnectEvm.ts
+++ b/packages/connect-kit/src/providers/WalletConnectEvm.ts
@@ -55,12 +55,16 @@ async function initWalletConnectProvider(): Promise<WalletConnectProvider> {
   log('walletConnectProviderOptions is', providerOptions);
 
   // merge optionalMethods with WalletConnect defaults ignoring duplicates
-  const optionalMethods = OPTIONAL_METHODS;
+  // WARN seems to be causing problems with eth_getBalance and eth_call
+  // const optionalMethods = OPTIONAL_METHODS;
+  const optionalMethods: string[] = [];
   if (providerOptions.optionalMethods && Array.isArray(providerOptions.optionalMethods))
     optionalMethods.push(...providerOptions.optionalMethods.filter((id) => optionalMethods.indexOf(id) < 0));
 
   // merge optionalEvents with WalletConnect defaults ignoring duplicates
-  const optionalEvents = OPTIONAL_EVENTS;
+  // WARN seems to be causing problems with eth_getBalance and eth_call
+  // const optionalEvents = OPTIONAL_EVENTS;
+  const optionalEvents: string[] = [];
   if (providerOptions.optionalEvents && Array.isArray(providerOptions.optionalEvents))
     optionalMethods.push(...providerOptions.optionalEvents.filter((id) => optionalEvents.indexOf(id) < 0));
 


### PR DESCRIPTION
See https://ledgerhq.atlassian.net/browse/LIVE-8849

- if we pass methods and optionalMethods as empty arrays to walletconnect.init we don’t have the eth_getBalance and eth_call errors but we get the same error for eth_signTypedData_v4
- so we have to pass eth_signTypedData_v4 on either the methods or optionalMethods parameters to be able to sign typed data
- if we pass eth_getBalance on the methods parameter we will not get an error but it seems the provider does not return a response
- if we pass eth_getBalance on the optionalMethods parameter we will get the error

Still need to compare baheviour with a WalletConnect connector.