### PR TITLE
Trigger 1.1.8 build for @ledgerhq/connect-kit-loader

### DIFF
--- a/.github/workflows/release_connect-kit-loader.yml
+++ b/.github/workflows/release_connect-kit-loader.yml
@@ -11,7 +11,7 @@ jobs:
       # use 'latest' for release, 'alpha' or 'beta' for pre-releases
       PKG_RELEASE_TAG: 'latest'
       # make sure it matches the version on package.json
-      PKG_VERSION: '1.1.2'
+      PKG_VERSION: '1.1.8'
       GIT_TAG_PREFIX: 'ckl-'
     steps:
       # Checkout project repository


### PR DESCRIPTION
We [triggered a release](https://github.com/LedgerHQ/connect-kit/commit/a4ba6946d8ab1906b040daf259c49dcd1dfdeeba) for [connect-kit](https://www.npmjs.com/package/@ledgerhq/connect-kit) but not for [connect-kit-loader](https://www.npmjs.com/package/@ledgerhq/connect-kit-loader)