### PR TITLE
Retrofit `@ledgerhq/connect-kit-loader` to be a synchronous loader instead

### DIFF
--- a/packages/connect-kit-loader/package.json
+++ b/packages/connect-kit-loader/package.json
@@ -32,6 +32,9 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c --compact"
   },
+  "dependencies": {
+    "@ledgerhq/connect-kit": "1.1.8"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/connect-kit-loader/rollup.config.js
+++ b/packages/connect-kit-loader/rollup.config.js
@@ -13,6 +13,7 @@ export default [
         file: packageJson.module,
         format: "esm",
         sourcemap: false,
+        inlineDynamicImports: true,
       },
     ],
     plugins: [
@@ -21,5 +22,5 @@ export default [
       typescript({ tsconfig: "./tsconfig.json" }),
       terser(),
     ],
-  }
+  },
 ];

--- a/packages/connect-kit-loader/src/index.ts
+++ b/packages/connect-kit-loader/src/index.ts
@@ -1,3 +1,4 @@
+import * as ConnectKit from "@ledgerhq/connect-kit";
 // chain
 
 export enum SupportedProviderImplementations {
@@ -33,8 +34,8 @@ export type CheckSupportOptions = {
 };
 
 export type CheckSupportResult = {
-  isLedgerConnectSupported: boolean;
-  isLedgerConnectEnabled: boolean;
+  isLedgerConnectSupported?: boolean;
+  isLedgerConnectEnabled?: boolean;
   isChainIdSupported?: boolean;
   providerImplementation: SupportedProviderImplementations;
 };
@@ -64,7 +65,7 @@ export interface EthereumProvider {
 // getProvider
 
 export enum SupportedProviders {
-  Ethereum = 'Ethereum',
+  Ethereum = "Ethereum",
 }
 
 export type ProviderResult = EthereumProvider;
@@ -80,31 +81,7 @@ export interface LedgerConnectKit {
 }
 
 export async function loadConnectKit(): Promise<LedgerConnectKit> {
-  const src = "https://cdn.jsdelivr.net/npm/@ledgerhq/connect-kit@1.1.8";
-  const globalName = "ledgerConnectKit";
-
-  return new Promise((resolve, reject) => {
-    const scriptId = `ledger-ck-script-${globalName}`;
-
-    // we don't support server side rendering, reject with no stack trace for now
-    if (typeof document === "undefined") {
-      reject("Connect Kit does not support server side");
-      return;
-    }
-
-    if (document.getElementById(scriptId)) {
-      resolve((window as { [key: string]: any })[globalName]);
-    } else {
-      const script = document.createElement("script");
-      script.src = src;
-      script.id = scriptId;
-      script.addEventListener("load", () => {
-        resolve((window as { [key: string]: any })[globalName]);
-      });
-      script.addEventListener("error", (e) => {
-        reject(e.error);
-      });
-      document.head.appendChild(script);
-    }
+  return new Promise((resolve) => {
+    resolve(ConnectKit);
   });
 }

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -4,7 +4,7 @@
   "description": "A library for dApps to integrate with the Ledger Extension and Ledger Live",
   "author": "Ledger SAS <ledger.com>",
   "license": "MIT",
-  "main": "dist/umd/index",
+  "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
   "files": [
     "dist"

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -4,12 +4,12 @@
   "description": "A library for dApps to integrate with the Ledger Extension and Ledger Live",
   "author": "Ledger SAS <ledger.com>",
   "license": "MIT",
-  "main": "dist/umd/index.js",
+  "main": "dist/umd/index",
   "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/umd/index.d.ts",
   "homepage": "https://ledger.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

Not using the async loader moving forward is a good decision, but many people need help upgrading their dependencies. For example, if you're using `wagmi` pre v1, it's hard to get to a recent version that would ensure you no longer load dependencies from the CDN. 

I propose taking a different approach and retrofitting this existing package and removing the `async` loading from it, but instead, add `@ledgerhq/connect-kit` as a dependency and return that from the loader function. The idea behind this is that we can publish a version of this package and then use npm `overrides` or yarn `resolutions` to force this retrofitted version of `@ledgerhq/connect-kit-loader` into your app without needing to update any other dependencies but removing the async part of the code.
