### PR TITLE
Chore/export provider interface from connect kit

### DIFF
--- a/.github/workflows/release_connect-kit.yml
+++ b/.github/workflows/release_connect-kit.yml
@@ -19,7 +19,7 @@ jobs:
       # use 'latest' for release, 'alpha' or 'beta' for pre-releases
       PKG_RELEASE_TAG: 'latest'
       # make sure it matches the version on package.json
-      PKG_VERSION: '1.1.8'
+      PKG_VERSION: '1.1.9'
       GIT_TAG_PREFIX: 'ck-'
     steps:
       # Checkout project repository

--- a/packages/connect-kit/CHANGELOG.md
+++ b/packages/connect-kit/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 1.1.9 - 2024-01-15
+Export SupportedProviders and EthereumProvider
+
 ## 1.1.8 - 2023-12-14
 New version fix
 

--- a/packages/connect-kit/package.json
+++ b/packages/connect-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/connect-kit",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A library for dApps to integrate with the Ledger Extension and Ledger Live",
   "author": "Ledger SAS <ledger.com>",
   "license": "MIT",

--- a/packages/connect-kit/src/index.ts
+++ b/packages/connect-kit/src/index.ts
@@ -1,3 +1,4 @@
 export { checkSupport } from "./lib/support";
-export { getProvider } from "./lib/provider";
+export { getProvider, SupportedProviders } from "./lib/provider";
 export { enableDebugLogs } from './lib/logger';
+export { EthereumProvider } from './providers/ExtensionEvm';

--- a/packages/connect-kit/src/lib/provider.ts
+++ b/packages/connect-kit/src/lib/provider.ts
@@ -17,8 +17,7 @@ export const DEFAULT_REQUIRED_CHAINS: number[] = [DEFAULT_CHAIN_ID];
 export const DEFAULT_WALLETCONNECT_VERSION: number = 1;
 
 export enum SupportedProviders {
-  Ethereum = 'Ethereum',
-  Solana = 'Solana',
+  Ethereum = 'Ethereum'
 }
 
 export enum SupportedProviderImplementations {


### PR DESCRIPTION
connect-kit-loader being deprecated means some of its exports need to be exported from the connect-kit directly, this PR includes: 
- connect-kit exports`SupportedProviders` enum
- connect-kit export `EthereumProvider` interface

The `SupportedProviders` enum removes `Solana`