### PR TITLE
chore: remove connect-kit-loader from README.md

### DIFF
--- a/packages/connect-kit/README.md
+++ b/packages/connect-kit/README.md
@@ -1,4 +1,1 @@
 # Ledger Connect Kit
-
-Please use Connect Kit Loader, read the information available on the
-[connect-kit-loader](../connect-kit-loader) package.


### PR DESCRIPTION
Despite the `!!!!!!!!!!!!!!!! IMPORTANT NOTICE !!!!!!!!!!!!!!!!` in Connect Kit Loader's README, Connect Kit's README still instructs you to use it.